### PR TITLE
Small change on Python example code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The contents of the module are renamed by default:
 
 In Python, the module (aka library) is called "openframeworks" and its members retain the "of" prefix:
 
-    import openframeworks
+    from openframeworks import *
     
     ofBackground(255)
     color = ofColor()


### PR DESCRIPTION
The Python example code depicted in README.md should use `from openframeworks import *` in order to use the functions and classes.
