### PR TITLE
adding GLint

### DIFF
--- a/openFrameworks.i
+++ b/openFrameworks.i
@@ -109,6 +109,9 @@ namespace std {
 	%template(StringVector) std::vector<std::string>;
 };
 
+// Needed to use functions with GLint args
+typedef int GLint;
+
 // ----- ofConstants.h -----
 
 %include "utils/ofConstants.h"


### PR DESCRIPTION
Some functions require GLint parameters, and those can't be provided unless SWIG knows something about GLint type.
