### PR TITLE
ofIndexType is not fully defined in SWIG

### DIFF
--- a/openFrameworks.i
+++ b/openFrameworks.i
@@ -112,6 +112,14 @@ namespace std {
 // Needed to use functions with GLint args
 typedef int GLint;
 
+
+// ofIndexType not fully defined in ofConstants.h
+#if TARGET_OS_IPHONE || ANDROID || __ARMEL__
+typedef unsigned short ofIndexType;
+#else
+typedef unsigned int ofIndexType;
+#endif
+
 // ----- ofConstants.h -----
 
 %include "utils/ofConstants.h"


### PR DESCRIPTION
So I extracted its definition from OF headers and put it here. This way We can use ofVbo methods, for instance.
