### PR TITLE
Fixing some python issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ openFrameworks-header:
 openFrameworks-symbols:
 	$(SWIG) -c++ -$(LANG) $(SWIG_FLAGS) -debug-lsymbols $(CFLAGS) $(OF_CFLAGS) openFrameworks.i > $(MODULE_NAME)_$(LANG)_symbols.txt
 	rm -f *.cxx
-	if [ $(LANG) == "python" ]; then rm -f *.py; fi
+	if [ $(LANG) = "python" ]; then rm -f *.py; fi
 
 # clean dest dir
 openFrameworks-clean:
@@ -153,7 +153,7 @@ glm:
 glm-symbols:
 	$(SWIG) -c++ -$(LANG) $(SWIG_FLAGS) -debug-lsymbols $(OF_HEADERS)/glm/include glm.i > glm_$(LANG)_symbols.txt
 	rm -f *.cxx
-	if [ $(LANG) == "python" ]; then rm -f *.py; fi
+	if [ $(LANG) = "python" ]; then rm -f *.py; fi
 
 # clean dest dir
 glm-clean:

--- a/openFrameworks/lang/python/python.i
+++ b/openFrameworks/lang/python/python.i
@@ -15,12 +15,7 @@
 
 %pythoncode %{
 
-# handle typedefs which swig doesn't wrap
-ofPoint = ofVec3f
-
-# renaming log -> ofLog
-ofLog = log
-del log
+OF_PRIMITIVE_TRIANGLE_STRIP = None
 
 %}
 


### PR DESCRIPTION
it turns out a simple early define of OF_PRIMITIVE_TRIANGLE_STRIP fixes the error with python (tested 3.6.7)

also fixing an error in the make file

This has not been tested extensively but at least this now runs in OF while drawing through python, i.e.:
```
def draw():
    color = ofColor( random.randint(0,255), random.randint(0,255), random.randint(0,255) )
    ofSetColor(color)
    ofDrawCircle( ofGetWidth()/2, ofGetHeight()/2, 100 )
```